### PR TITLE
Use transient Toplevel popup for instruction selector dropdown and dynamic repositioning

### DIFF
--- a/SALSA/GUI/ProjectEditor/instruction_selector.py
+++ b/SALSA/GUI/ProjectEditor/instruction_selector.py
@@ -46,7 +46,7 @@ class InstructionSelectorWidget(ttk.Frame):
     shift_up_idx = 7
     shift_down_idx = 3
 
-    def __init__(self, parent, callbacks, inst_trace, x, y, *args, **kwargs):
+    def __init__(self, parent, callbacks, inst_trace, *args, **kwargs):
         super().__init__(parent, *args, **kwargs)
 
         self.callbacks = callbacks
@@ -69,11 +69,22 @@ class InstructionSelectorWidget(ttk.Frame):
         r_callbacks = {
             'select': self.select_inst
         }
-        self.result_dropdown = DataTreeview(parent, name='result', callbacks=r_callbacks)
-        self.result_dropdown.place(x=x, y=y, anchor='nw')
+        self.dropdown_root = self.winfo_toplevel()
+        self.dropdown_popup = tk.Toplevel(self.dropdown_root)
+        self.dropdown_popup.overrideredirect(True)
+        self.dropdown_popup.transient(self.dropdown_root)
+        self.dropdown_popup.columnconfigure(0, weight=1)
+        self.dropdown_popup.rowconfigure(0, weight=1)
+
+        self.result_dropdown = DataTreeview(self.dropdown_popup, name='result', callbacks=r_callbacks)
+        self.result_dropdown.grid(row=0, column=0, sticky=tk.NSEW)
         self.result_dropdown.heading('#0', text='Relevant Instructions')
         self.result_dropdown.configure(show='tree')
         self.result_dropdown.configure(height=1)
+
+        self._root_configure_binding = self.dropdown_root.bind('<Configure>', self.reposition_dropdown, add='+')
+        self.bind('<Configure>', self.reposition_dropdown, add='+')
+        self.search.bind('<Configure>', self.reposition_dropdown, add='+')
 
         self.relevant_entries = []
         self.relevant_index = 0
@@ -100,6 +111,22 @@ class InstructionSelectorWidget(ttk.Frame):
         self.result_dropdown.bind("<Motion>", self.on_hover)
 
         self.after(10, self.update_search, '')
+        self.after_idle(self.reposition_dropdown)
+
+    def reposition_dropdown(self, event=None):
+        if event is not None and event.widget == self.dropdown_popup:
+            return
+        if not self.winfo_exists() or not self.dropdown_popup.winfo_exists():
+            return
+
+        self.update_idletasks()
+        dropdown_width = max(self.search.winfo_width(), self.result_dropdown.winfo_reqwidth())
+        dropdown_height = self.result_dropdown.winfo_reqheight()
+        x = self.search.winfo_rootx()
+        y = self.search.winfo_rooty() + self.search.winfo_height()
+
+        self.dropdown_popup.geometry(f'{dropdown_width}x{dropdown_height}+{x}+{y}')
+        self.dropdown_popup.lift(self.dropdown_root)
 
     def update_search(self, current):
         self.update_relevant_entries(self.callbacks['get_relevant'](current, exclude_modifiers=True))
@@ -111,6 +138,8 @@ class InstructionSelectorWidget(ttk.Frame):
     def update_menu(self, start_index=0):
         self.result_dropdown.clear_all_entries()
         if len(self.relevant_entries) == 0:
+            self.result_dropdown.configure(height=1)
+            self.after_idle(self.reposition_dropdown)
             return
         rows = min(self.entry_max, len(self.relevant_entries))
         rows = max(rows, 1)
@@ -126,6 +155,7 @@ class InstructionSelectorWidget(ttk.Frame):
             inst_id = entry_parts[0]
             self.result_dropdown.insert_entry(parent='', index='end', text=entry, values=[], row_data=inst_id)
         self.result_dropdown.selection_set(self.result_dropdown.get_children('')[0])
+        self.after_idle(self.reposition_dropdown)
 
     def select_inst(self, name, new_ID):
         end_callback = self.finish_select_inst
@@ -231,10 +261,17 @@ class InstructionSelectorWidget(ttk.Frame):
             return
         self.select_inst(name=None, new_ID=self.result_dropdown.row_data[self.result_dropdown.identify_row(e.y)[0]])
 
+    def destroy_dropdown(self):
+        if self._root_configure_binding is not None:
+            self.dropdown_root.unbind('<Configure>', self._root_configure_binding)
+            self._root_configure_binding = None
+        if self.dropdown_popup.winfo_exists():
+            self.dropdown_popup.destroy()
+
     def close(self):
-        self.result_dropdown.destroy()
+        self.destroy_dropdown()
         self.callbacks['destroy_widget']()
 
     def cancel(self):
-        self.result_dropdown.destroy()
+        self.destroy_dropdown()
         self.callbacks['cancel_add_inst'](self.inst_trace[2])

--- a/SALSA/GUI/ProjectEditor/project_editor_controller.py
+++ b/SALSA/GUI/ProjectEditor/project_editor_controller.py
@@ -981,8 +981,7 @@ class ProjectEditorController:
         cell_bbox = self.trees['instruction'].bbox(sel_iid, 'name')
         x_mod = self.trees['instruction'].winfo_x()
         y_mod = self.trees['instruction'].winfo_y()
-        w = InstructionSelectorWidget(self.view.inst_tree_frame, callbacks, inst_trace,
-                                      x=cell_bbox[0] + x_mod, y=cell_bbox[1] + y_mod + cell_bbox[3])
+        w = InstructionSelectorWidget(self.view.inst_tree_frame, callbacks, inst_trace)
         w.place(x=cell_bbox[0] + x_mod, y=cell_bbox[1] + y_mod, w=cell_bbox[2], h=cell_bbox[3])
         self.entry_widget = w
         for tree in self.trees.values():


### PR DESCRIPTION
### Motivation

- Replace the in-parent absolute-placed results list with a floating popup so the instruction search dropdown can overlap other widgets and reposition with the main window.
- Ensure the dropdown auto-sizes and repositions when the root or selector is resized or moved to avoid misplaced search results.
- Centralize dropdown teardown to avoid leaving stale bindings or popup windows when the selector is closed or cancelled.

### Description

- Updated `InstructionSelectorWidget.__init__` to remove `x,y` parameters and create a `Toplevel` popup (`self.dropdown_popup`) as a transient, borderless container for the `DataTreeview` results instead of placing the tree on the parent; the tree is now gridded into the popup. 
- Added `reposition_dropdown` which computes and sets the popup geometry based on the search widget and results size and bound it to root and widget configure events; calls to `update_menu` now schedule repositioning via `after_idle` to ensure correct sizing. 
- Added `destroy_dropdown` to unbind the root configure handler and destroy the popup, and updated `close` and `cancel` to call it; adjusted result height handling for empty results and added `after_idle` repositioning in `update_menu`. 
- Updated `ProjectEditorController.show_inst_selector` to instantiate `InstructionSelectorWidget` without `x,y` arguments and continue to place the selector widget at the tree cell bbox on the editor frame. 

### Testing

- Ran the project's automated test suite with `pytest -q` and the tests completed successfully. 
- Executed the GUI selector creation/close code paths under automated UI smoke tests and they passed without leaving orphaned popups or bindings. 
- Ran linters and static checks which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087a798e04832eb9303ba050dc1c35)